### PR TITLE
Update TwoBitFullAdder child name

### DIFF
--- a/TwoBitFullAdder.txt
+++ b/TwoBitFullAdder.txt
@@ -1,7 +1,7 @@
 ﻿# TwoBitFullAdder.txt
 PARAMS: A0:state A1:state B0:state B1:state Cin:state Sum0:int Sum1:int Cout:int
 MAIN-PROCESS TwoBitFullAdder
-DECLARECHILD OneBitFullAdder
+DECLARECHILD SingleBitFullAdder
 CYCLE 2
 CREATETOKEN -I Cmid
 SET Cmid:0 0p
@@ -10,14 +10,14 @@ SET Cmid:0 0p
 SET A0:0   $A0
 SET B0:0   $B0
 SET Cin:0  $Cin
-RUNCHILD OneBitFullAdder -I $A0 $B0 $Cin      -O Sum0 Cmid:0
+RUNCHILD SingleBitFullAdder -I $A0 $B0 $Cin      -O Sum0 Cmid:0
 ACCEPTVALS Sum0 Cmid
 
 # bit1 at cycle1
 CYCLE 1
 SET A1:1   $A1
 SET B1:1   $B1
-RUNCHILD OneBitFullAdder -I $A1 $B1 Cmid:0    -O Sum1 Cout:1
+RUNCHILD SingleBitFullAdder -I $A1 $B1 Cmid:0    -O Sum1 Cout:1
 ACCEPTVALS Sum1 Cout
 
 DELETETOKEN -I Cmid


### PR DESCRIPTION
## Summary
- switch child references to use `SingleBitFullAdder` instead of `OneBitFullAdder`

## Testing
- `python unittests.py` *(fails: SUM/COUT mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_687038a73594832da05c2cedc549c1d4