### PR TITLE
Refactor adders

### DIFF
--- a/SingleBitFullAdder.txt
+++ b/SingleBitFullAdder.txt
@@ -1,61 +1,27 @@
-﻿PARAMS: A:1 B:1 Cin:1
+PARAMS: A:1 B:1 Cin:1
 
 MAIN-PROCESS SingleBitFullAdder
-CYCLE 2
+CYCLE 1
 
-# Initialize inputs and working qubits
-SET 0:0 $A    # Input A
-SET 1:0 $B    # Input B
-SET 2:0 $Cin  # Input Cin
-SET 3:0 0p    # SUM qubit (init |0⟩)
-SET 4:0 0p    # Carry temp (init |0⟩)
-SET 0:1 0p    # Carry temp (init |0⟩)
+# Load inputs
+SET 0:0 $A
+SET 1:0 $B
+SET 2:0 0p
+CNOT -I $Cin -O 2:0
+SET 3:0 0p    # Sum
+SET 4:0 0p    # Cout
 
-# Compute SUM = A ⊕ B ⊕ Cin
-CNOT -I 0:0 -O 3:0  # A → SUM
-CNOT -I 1:0 -O 3:0  # B → SUM (SUM = A⊕B)
-CNOT -I 2:0 -O 3:0  # Cin → SUM (SUM = A⊕B⊕Cin)
+# Sum = A XOR B XOR Cin
+CNOT -I 0:0 -O 3:0
+CNOT -I 1:0 -O 3:0
+CNOT -I 2:0 -O 3:0
 
-# Compute carry-out using majority function:
-# Cout = (A∧B) ∨ (A∧Cin) ∨ (B∧Cin)
-
-# First compute A AND B into temp1 (qubit 4)
+# Cout = majority(A,B,Cin)
 CCNOT -I 0:0 1:0 -O 4:0
-
-# Compute A AND Cin into temp2 (qubit 5)
-CCNOT -I 0:0 2:0 -O 0:1
-
-# Compute B AND Cin and OR with previous results
-# Using the identity: x ∨ y = ¬(¬x ∧ ¬y)
-# We'll accumulate into Cout (qubit 2)
-
-# First copy temp1 (A∧B) to Cout
-CNOT -I 4:0 -O 2:0
-
-# Compute OR with temp2 (A∧Cin) using DeMorgan's:
-# x ∨ y = ¬(¬x ∧ ¬y)
-# So we first NOT both operands
-X -I 2:0 -O 2:0  # NOT Cout
-X -I 0:1 -O 0:1  # NOT temp2
-# Then AND them
-CCNOT -I 2:0 0:1 -O 2:0
-# Then NOT the result
-X -I 2:0 -O 2:0
-
-# Now handle third term (B∧Cin) similarly
-# First compute B∧Cin into temp1 (qubit 4)
+CCNOT -I 0:0 2:0 -O 4:0
 CCNOT -I 1:0 2:0 -O 4:0
 
-# NOT Cout and temp1
-X -I 2:0 -O 2:0
-X -I 4:0 -O 4:0
-# AND them
-CCNOT -I 2:0 4:0 -O 2:0
-# NOT the final result
-X -I 2:0 -O 2:0
+MEASURE -I 3
+MEASURE -I 4
 
-# Measurement
-MEASURE -I 3:0  # SUM
-MEASURE -I 2:0  # Cout
-
-RETURNVALS 3 2
+RETURNVALS 3 4

--- a/TwoBitFullAdder.txt
+++ b/TwoBitFullAdder.txt
@@ -17,7 +17,7 @@ ACCEPTVALS Sum0 Cmid
 CYCLE 1
 SET A1:1   $A1
 SET B1:1   $B1
-RUNCHILD SingleBitFullAdder -I $A1 $B1 Cmid:0    -O Sum1 Cout:1
+RUNCHILD SingleBitFullAdder -I $A1 $B1 Cmid    -O Sum1 Cout:1
 ACCEPTVALS Sum1 Cout
 
 DELETETOKEN -I Cmid

--- a/cli.py
+++ b/cli.py
@@ -188,8 +188,10 @@ class CircuitSimulator:
 
         # gather return values from final local cycle
         ret_vals = []
+        from qpu.ast import interpret_token
         for key in self.child_return_keys:
-            val = readdress_value(self.memory, key, local_cycle - 1, self.qpu)
+            k = interpret_token(key)
+            val = readdress_value(self.memory, k, local_cycle - 1, self.qpu)
             ret_vals.append(val)
 
         # Collect updated states of injected parent tokens, only if changed

--- a/unittests.py
+++ b/unittests.py
@@ -1,108 +1,98 @@
-﻿import unittest
+import unittest
 import numpy as np
 import os
-from qpu.ast import (
-    read_protocol_file,
-    parse_parameters,
-    substitute_parameters,
-    parse_command,
-    MainProcessASTNode,
-    CycleASTNode,
-)
+from qpu.ast import parse_command
 from qpu.qpu_base import QuantumProcessorUnit
-from qpu.hilbert import HilbertSpace
+from cli import CircuitSimulator
 
 
-class TestQuantumFullAdder(unittest.TestCase):
+def run_process(proc_file, proc_name, params):
+    sim = CircuitSimulator(QuantumProcessorUnit(num_qubits=5))
+    sim.current_cycle = 0
+    cwd = os.getcwd()
+    proto_dir = os.path.dirname(proc_file)
+    os.chdir(proto_dir)
+    try:
+        compile_cmd = f"COMPILEPROCESS --NAME {proc_name} {os.path.basename(proc_file)}"
+        parse_command(compile_cmd).evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+        call_args = ' '.join(params)
+        call_cmd = f"CALL {proc_name} -I {call_args}"
+        parse_command(call_cmd).evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+    finally:
+        os.chdir(cwd)
+    return sim
+
+
+class TestSingleBitAdder(unittest.TestCase):
     def setUp(self):
         self.zero = np.array([1.0, 0.0], dtype=complex)
-        self.one  = np.array([0.0, 1.0], dtype=complex)
-        # full path to the protocol
-        self.protocol_file = os.path.join(
-            os.path.dirname(__file__),
-            "SingleBitFullAdder.txt"
-        )
+        self.one = np.array([0.0, 1.0], dtype=complex)
+        self.proc_file = os.path.join(os.path.dirname(__file__), "SingleBitFullAdder.txt")
         self.proc_name = "SingleBitFullAdder"
-        self.basename  = "SingleBitFullAdder.txt"
-
         self.cases = [
             ("0p", "0p", "0p", self.zero, self.zero),
-            ("0p", "0p", "1p", self.one, self.zero),  # 0+0+1 → Cout=0
+            ("0p", "0p", "1p", self.one, self.zero),
             ("0p", "1p", "0p", self.one, self.zero),
             ("0p", "1p", "1p", self.zero, self.one),
             ("1p", "0p", "0p", self.one, self.zero),
             ("1p", "0p", "1p", self.zero, self.one),
-            ("1p", "1p", "0p", self.one, self.zero),  # 1+1+0 → Cout=1
+            ("1p", "1p", "0p", self.zero, self.one),
             ("1p", "1p", "1p", self.one, self.one),
         ]
 
-    def run_protocol(self, A: str, B: str, Cin: str):
-        # Minimal simulator harness
-        class Simulator:
-            def __init__(self):
-                self.memory               = {}
-                self.custom_tokens        = {}
-                self.current_cycle        = 0
-                self.qpu                  = QuantumProcessorUnit(num_qubits=5)
-                self.hilbert              = HilbertSpace()
-                self.compiled_processes   = {}
-                self.subprocess_depth     = 0
+    def test_all_combinations(self):
+        for A, B, Cin, exp_sum, exp_cout in self.cases:
+            with self.subTest(A=A, B=B, Cin=Cin):
+                sim = run_process(self.proc_file, self.proc_name, [A, B, Cin])
+                s_cycle = max(sim.memory[3].keys())
+                c_cycle = max(sim.memory[4].keys())
+                s = sim.memory[3][s_cycle]
+                c = sim.memory[4][c_cycle]
+                np.testing.assert_allclose(s, exp_sum, atol=1e-7)
+                np.testing.assert_allclose(c, exp_cout, atol=1e-7)
 
-            def run_cycle(self, suppress_output=False):
-                self.current_cycle += 1
 
-        sim = Simulator()
+class TestTwoBitAdder(unittest.TestCase):
+    def setUp(self):
+        self.zero = np.array([1.0, 0.0], dtype=complex)
+        self.one = np.array([0.0, 1.0], dtype=complex)
+        self.proc_file = os.path.join(os.path.dirname(__file__), "TwoBitFullAdder.txt")
+        self.proc_name = "TwoBitFullAdder"
 
-        # chdir into the protocol's dir so COMPILEPROCESS can find it by basename
-        cwd = os.getcwd()
-        proto_dir = os.path.dirname(self.protocol_file)
-        os.chdir(proto_dir)
-
-        try:
-            # 1) COMPILEPROCESS --NAME SingleBitFullAdder SingleBitFullAdder.txt
-            compile_cmd = f"COMPILEPROCESS --NAME {self.proc_name} {self.basename}"
-            compile_node = parse_command(compile_cmd)
-            compile_node.evaluate(
-                sim.memory,
-                sim.current_cycle,
-                sim.qpu,
-                sim.hilbert,
-                sim
-            )
-
-            # 2) CALL SingleBitFullAdder -I A B Cin
-            call_cmd = f"CALL {self.proc_name} -I {A} {B} {Cin}"
-            call_node = parse_command(call_cmd)
-            # we can ignore the returned transcript; all state is in sim.memory
-            call_node.evaluate(
-                sim.memory,
-                sim.current_cycle,
-                sim.qpu,
-                sim.hilbert,
-                sim
-            )
-        finally:
-            os.chdir(cwd)
-
-        # The protocol measures SUM into physical qubit 3 at cycle 0
-        # and COUT into qubit 2 at cycle 0
-        sum_state  = sim.memory[3][0]
-        cout_state = sim.memory[2][0]
-        return sum_state, cout_state
+    def expected(self, A0, A1, B0, B1, Cin):
+        a = (int(A1[-2]) << 1) | int(A0[-2])
+        b = (int(B1[-2]) << 1) | int(B0[-2])
+        cin = int(Cin[-2])
+        total = a + b + cin
+        s0 = (total & 1)
+        s1 = (total >> 1) & 1
+        cout = (total >> 2) & 1
+        return (self.one if s0 else self.zero,
+                self.one if s1 else self.zero,
+                self.one if cout else self.zero)
 
     def test_all_combinations(self):
-        for A, B, Cin, expected_sum, expected_cout in self.cases:
-            with self.subTest(A=A, B=B, Cin=Cin):
-                s, c = self.run_protocol(A, B, Cin)
-                np.testing.assert_allclose(
-                    s, expected_sum, atol=1e-7,
-                    err_msg=f"SUM mismatch for A={A},B={B},Cin={Cin}"
-                )
-                np.testing.assert_allclose(
-                    c, expected_cout, atol=1e-7,
-                    err_msg=f"COUT mismatch for A={A},B={B},Cin={Cin}"
-                )
+        bits = ["0p", "1p"]
+        for A0 in bits:
+            for A1 in bits:
+                for B0 in bits:
+                    for B1 in bits:
+                        for Cin in bits:
+                            with self.subTest(A0=A0, A1=A1, B0=B0, B1=B1, Cin=Cin):
+                                sim = run_process(self.proc_file, self.proc_name,
+                                                  [A0, A1, B0, B1, Cin])
+                                s0_cycle = max(sim.memory["Sum0"].keys())
+                                s1_cycle = max(sim.memory["Sum1"].keys())
+                                cout_cycle = max(sim.memory["Cout"].keys())
+                                s0 = sim.memory["Sum0"][s0_cycle]
+                                s1 = sim.memory["Sum1"][s1_cycle]
+                                cout = sim.memory["Cout"][cout_cycle]
+                                exp_s0, exp_s1, exp_cout = self.expected(A0, A1, B0, B1, Cin)
+                                np.testing.assert_allclose(s0, exp_s0, atol=1e-7)
+                                np.testing.assert_allclose(s1, exp_s1, atol=1e-7)
+                                np.testing.assert_allclose(cout, exp_cout, atol=1e-7)
 
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- reimplement single-bit adder without invalid custom controls
- propagate child results back to parent tokens
- adjust two-bit adder to pass carry between child calls
- simplify gate model for classical behaviour
- rewrite tests for correct expectations

## Testing
- `python unittests.py`

------
https://chatgpt.com/codex/tasks/task_e_68715877f8d8832d897e11ce6d95ef6e