### PR TITLE
Enable direct Hilbert-space logging for QPU gates

### DIFF
--- a/qpu/ast.py
+++ b/qpu/ast.py
@@ -405,6 +405,7 @@ class SetASTNode:
 
         if isinstance(self.key, int) and self.key < qpu.num_qubits:
             qpu.local_states[self.key] = state
+            qpu.rebuild_global_state()
         else:
             qpu.custom_states[self.key] = state
             simulator.custom_tokens[self.key] = self.key

--- a/unittests.py
+++ b/unittests.py
@@ -127,5 +127,26 @@ for idx, combo in enumerate(_two_bit_combos):
     setattr(TestTwoBitAdder, name, _make_two_bit_test(*combo))
 
 
+# -------------------------------------------------------------------
+# Direct gate interaction with Hilbert space
+# -------------------------------------------------------------------
+class TestGateHilbert(unittest.TestCase):
+    def test_cnot_logs_hilbert(self):
+        qpu = QuantumProcessorUnit(num_qubits=2)
+        hilbert = qpu.hilbert if hasattr(qpu, 'hilbert') else None
+        if hilbert is None:
+            from qpu.hilbert import HilbertSpace
+            hilbert = HilbertSpace()
+        # initialize control |1> and target |0>
+        qpu.local_states[0] = np.array([0,1], dtype=complex)
+        qpu.local_states[1] = np.array([1,0], dtype=complex)
+        qpu.rebuild_global_state()
+
+        qpu.apply_cnot(0, 1, cycle=0, hilbert=hilbert)
+
+        self.assertIn((1, 0), hilbert.space)
+        np.testing.assert_allclose(hilbert.space[(1,0)], np.array([0,1], dtype=complex))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- refresh global state whenever physical qubits are set
- allow gates to accept a HilbertSpace and cycle for logging
- rebuild global state with LSB ordering and expose helpers for extraction
- add unit test for CNOT logging directly through QPU

## Testing
- `python unittests.py`

------
https://chatgpt.com/codex/tasks/task_e_686ff8c07b74832da8b967b3e7c1f006