### PR TITLE
Add cycle stack and snapshot functionality

### DIFF
--- a/qpu/hilbert.py
+++ b/qpu/hilbert.py
@@ -29,6 +29,10 @@ class HilbertSpace:
         """
         self.space[(register, cycle)] = value
 
+    def output_all(self, cycle: int, value):
+        """Record a full-system snapshot under key '__all__'."""
+        self.space[("__all__", cycle)] = value
+
     def input(self, register, cycle: int):
         """
         Retrieves and removes the value stored under (register, cycle).

--- a/qpu/qpu_base.py
+++ b/qpu/qpu_base.py
@@ -365,6 +365,24 @@ class QuantumProcessorUnit:
         return bits, collapsed
 
     # ----------------------------------------------------------------
+    # State serialization helpers
+    # ----------------------------------------------------------------
+
+    def get_states(self):
+        return {
+            "local_states": [s.copy() for s in self.local_states],
+            "custom_states": {k: v.copy() for k, v in self.custom_states.items()},
+        }
+
+    def set_states(self, data):
+        self.local_states = [np.array(s) for s in data["local_states"]]
+        self.custom_states = {k: np.array(v) for k, v in data["custom_states"].items()}
+        self.rebuild_global_state()
+
+    def full_state_vector(self):
+        return self.state.copy()
+
+    # ----------------------------------------------------------------
     # Device‐fingerprint methods
     # ----------------------------------------------------------------
 

--- a/unittests.py
+++ b/unittests.py
@@ -148,5 +148,21 @@ class TestGateHilbert(unittest.TestCase):
         np.testing.assert_allclose(hilbert.space[(1,0)], np.array([0,1], dtype=complex))
 
 
+class TestCycleMechanics(unittest.TestCase):
+    def test_increasecycle(self):
+        sim = CircuitSimulator(QuantumProcessorUnit(num_qubits=2))
+        start = sim.current_cycle
+        parse_command("INCREASECYCLE").evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+        self.assertEqual(sim.current_cycle, start + 1)
+
+    def test_save_and_load_state(self):
+        sim = CircuitSimulator(QuantumProcessorUnit(num_qubits=1))
+        parse_command("SET 0 1p").evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+        parse_command("SAVE_STATE snap").evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+        parse_command("SET 0 0p").evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+        parse_command("LOAD_STATE snap").evaluate(sim.memory, sim.current_cycle, sim.qpu, sim.hilbert, sim)
+        np.testing.assert_allclose(sim.qpu.local_states[0], np.array([0.0,1.0], dtype=complex))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- overhaul simulator clocks with `ClockFrame` stacks
- support `INCREASECYCLE` command and child process frames
- integrate Hilbert logging helper
- add state checkpoint save/load
- provide serialization helpers in the QPU
- tests for new cycle and snapshot features

## Testing
- `python unittests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d983d0dc832db450e96be59d9ab4